### PR TITLE
Fix for sites installed under a subdirectory of the webroot

### DIFF
--- a/model/handlers/masaauthenticator.cfc
+++ b/model/handlers/masaauthenticator.cfc
@@ -4,7 +4,7 @@ component extends="mura.cfobject" output="false" {
 
     function init() {
         var thispath = RemoveChars(GetDirectoryFromPath(GetCurrentTemplatePath()), 1, Len(application.configBean.get('webroot')));
-        var modulepath = Left(thispath, Len(thispath)-Len('/model/handlers/'));
+        var modulepath = application.configBean.get('context') & Left(thispath, Len(thispath)-Len('/model/handlers/'));
         set('modulepath', modulepath);
         return this;
     }


### PR DESCRIPTION
A fix to take account of the site context so the module works when the site is installed in a subdirectory.